### PR TITLE
Cloud Runへのデプロイ用のシェルスクリプトを追加

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
+# Secret Managerから取得するため、以下は入力しなくても動作します。
 GOOGLE_CREDENTIALS_BASE64=
 GOOGLE_SPREADSHEET_ID=
 CLIENT_MAIL=
@@ -5,3 +6,7 @@ PORT=
 BUCKET_NAME=
 AUTH_SECRET=
 SLACK_WEBHOOK_URL=
+# 以下はSecret Managerから取得しないため、.envに入力する必要があります。
+SERVICE_NAME=your-service-name
+REGION=asia-northeast1
+SERVICE_ACCOUNT=your-service@your-project.iam.gserviceaccount.com

--- a/deploy_google_cloud.sh
+++ b/deploy_google_cloud.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# 環境変数ファイルを読み込み
+if [ -f .env ]; then
+  export $(cat .env | grep -v '^#' | xargs)
+else
+  echo "❌ .envファイルが見つかりません"
+  echo "💡 .env.exampleをコピーして.envを作成してください"
+  exit 1
+fi
+
+# 色付きログ
+info()  { echo -e "\033[1;34m[INFO]\033[0m $1"; }
+error() { echo -e "\033[1;31m[ERROR]\033[0m $1"; }
+
+info "設定値確認:"
+info "  SERVICE_NAME: $SERVICE_NAME"
+info "  REGION: $REGION"
+info "  SERVICE_ACCOUNT: $SERVICE_ACCOUNT"
+
+info "Cloud Run にデプロイ中..."
+if ! gcloud run deploy $SERVICE_NAME \
+  --source . \
+  --region=$REGION \
+  --service-account=$SERVICE_ACCOUNT \
+  --set-secrets=GOOGLE_SPREADSHEET_ID=GOOGLE_SPREADSHEET_ID:latest,BUCKET_NAME=BUCKET_NAME:latest,AUTH_SECRET=AUTH_SECRET:latest,SLACK_WEBHOOK_URL=SLACK_WEBHOOK_URL:latest \
+  --allow-unauthenticated; then
+  error "デプロイ失敗"
+
+  # Slack Webhook を Secret Manager から取得
+  SLACK_WEBHOOK_URL=$(gcloud secrets versions access latest --secret=SLACK_WEBHOOK_URL 2>/dev/null)
+
+  if [ -n "$SLACK_WEBHOOK_URL" ]; then
+    curl -X POST -H "Content-Type: application/json" \
+      -d "{\"text\": \"❌ Cloud Run デプロイに失敗しました: *${SERVICE_NAME}*\"}" \
+      "$SLACK_WEBHOOK_URL"
+  else
+    error "Slack通知失敗：Webhook URL が取得できませんでした"
+  fi
+
+  exit 1
+fi
+
+info "デプロイ完了、URL取得中..."
+SERVICE_URL=$(gcloud run services describe $SERVICE_NAME \
+  --region=$REGION \
+  --format='value(status.url)')
+
+# Slack Webhook 取得
+SLACK_WEBHOOK_URL=$(gcloud secrets versions access latest --secret=SLACK_WEBHOOK_URL 2>/dev/null)
+
+if [ -n "$SLACK_WEBHOOK_URL" ]; then
+  SLACK_TEXT="✅ *Cloud Run デプロイ完了*\nサービス名: *${SERVICE_NAME}*\nURL: ${SERVICE_URL}"
+
+  curl -X POST -H "Content-Type: application/json" \
+    -d "{\"text\": \"$SLACK_TEXT\"}" \
+    "$SLACK_WEBHOOK_URL"
+
+  info "Slackに通知しました ✅"
+else
+  error "Slack通知失敗：Webhook URL が取得できませんでした"
+fi

--- a/docs/endpoint/README.md
+++ b/docs/endpoint/README.md
@@ -1,0 +1,23 @@
+# Cloud Runにセットアップしたエンドポイントについて
+
+## デプロイ方法
+
+デプロイ方法は現状2種類あります。
+
+### シェルスクリプトから実行
+
+1. `.env.example` をコピーして、 `.env` を作成
+2. `.env` に実際の設定値を入力
+3. `./deploy_google_cloud.sh` を実行
+
+### コマンド
+
+`.env` ファイルがあるディレクトリで実行してください。
+
+```
+gcloud run deploy $SERVICE_NAME \
+  --source . \
+  --region=$REGION \
+  --service-account=$SERVICE_ACCOUNT \
+  --set-secrets=GOOGLE_SPREADSHEET_ID=GOOGLE_SPREADSHEET_ID:latest,BUCKET_NAME=BUCKET_NAME:latest,AUTH_SECRET=AUTH_SECRET:latest,SLACK_WEBHOOK_URL=SLACK_WEBHOOK_URL:latest
+```


### PR DESCRIPTION
## やった事

- Cloud Runに簡単にデプロイしたい
- Cloud Runにデプロイ後、Slack通知で気付けるようにしたい
- 上記を解決するため、一旦シェルスクリプトを追加しました。

## 次のステップ

シェルスクリプトからコマンドデプロイではなく、
GitHub連携し、mainブランチにマージされたら、Cloud Buildで検知しビルドさせる。